### PR TITLE
Fix Gemfile for public access

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
-gem 'newrelic_plugin', :git => 'git@github.com:newrelic-platform/newrelic_plugin.git', :branch => 'release'
+gem 'newrelic_plugin', :github => 'newrelic-platform/newrelic_plugin', :branch => 'release'
 gem "aws-sdk", "1.9.1"


### PR DESCRIPTION
With the old path, Github would reject the ssh credentials for people not on the newrelic team.
