### PR TITLE
lock the newrelic_plugin gem down to the bugfix level due to upcoming in...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
-gem 'newrelic_plugin'
+gem 'newrelic_plugin', '~> 1.0.3'
 gem "aws-sdk", "1.9.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: git@github.com:newrelic-platform/newrelic_plugin.git
-  revision: e5c20e1a333d6de16be1c690e5e5704bf7637ce8
-  branch: release
-  specs:
-    newrelic_plugin (0.3.0)
-      faraday (>= 0.8.1)
-      json
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -19,6 +10,9 @@ GEM
     json (1.8.0)
     mini_portile (0.5.0)
     multipart-post (1.2.0)
+    newrelic_plugin (1.0.3)
+      faraday (>= 0.8.1)
+      json
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
     uuidtools (2.1.4)
@@ -28,4 +22,4 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk (= 1.9.1)
-  newrelic_plugin!
+  newrelic_plugin (~> 1.0.3)


### PR DESCRIPTION
...ternal API changes in the newrelic_plugin

@rantler can you review this?
@portertech we are going to be making some changes to the SDK that will not be compatible with how this plugin currently interacts with the SDK. This change will prevent users from getting an incompatible version of the SDK.
