### PR TITLE
Handle AWS ids that are numeric

### DIFF
--- a/lib/newrelic_aws/collectors/ebs.rb
+++ b/lib/newrelic_aws/collectors/ebs.rb
@@ -38,7 +38,7 @@ module NewRelicAWS
               :unit        => unit,
               :dimension   => {
                 :name  => "VolumeId",
-                :value => volume.id
+                :value => volume.id.to_s
               },
               :period => detailed ? 60 : 300,
               :start_time => (Time.now.utc-(detailed ? 120 : 660)).iso8601,

--- a/lib/newrelic_aws/collectors/ec.rb
+++ b/lib/newrelic_aws/collectors/ec.rb
@@ -73,7 +73,7 @@ module NewRelicAWS
                 :dimensions  => [
                   {
                     :name  => "CacheClusterId",
-                    :value => cluster[:id]
+                    :value => cluster[:id].to_s
                   },
                   {
                     :name => "CacheNodeId",

--- a/lib/newrelic_aws/collectors/ec2.rb
+++ b/lib/newrelic_aws/collectors/ec2.rb
@@ -34,7 +34,7 @@ module NewRelicAWS
               :unit        => unit,
               :dimension   => {
                 :name  => "InstanceId",
-                :value => instance.id
+                :value => instance.id.to_s
               },
               :period => detailed ? 60 : 300,
               :start_time => (Time.now.utc-(detailed ? 120 : 660)).iso8601,

--- a/lib/newrelic_aws/collectors/elb.rb
+++ b/lib/newrelic_aws/collectors/elb.rb
@@ -36,7 +36,7 @@ module NewRelicAWS
               :unit        => unit,
               :dimension   => {
                 :name  => "LoadBalancerName",
-                :value => load_balancer_name
+                :value => load_balancer_name.to_s
               }
             )
             unless data_point.nil?

--- a/lib/newrelic_aws/collectors/rds.rb
+++ b/lib/newrelic_aws/collectors/rds.rb
@@ -40,7 +40,7 @@ module NewRelicAWS
               :unit        => unit,
               :dimension   => {
                 :name  => "DBInstanceIdentifier",
-                :value => instance_id
+                :value => instance_id.to_s
               }
             )
             unless data_point.nil?

--- a/lib/newrelic_aws/collectors/sns.rb
+++ b/lib/newrelic_aws/collectors/sns.rb
@@ -30,7 +30,7 @@ module NewRelicAWS
               :unit        => unit,
               :dimension   => {
                 :name  => "TopicName",
-                :value => topic_name
+                :value => topic_name.to_s
               },
               :period => 300,
               :start_time => (Time.now.utc-660).iso8601

--- a/lib/newrelic_aws/collectors/sqs.rb
+++ b/lib/newrelic_aws/collectors/sqs.rb
@@ -34,7 +34,7 @@ module NewRelicAWS
               :unit        => unit,
               :dimension   => {
                 :name  => "QueueName",
-                :value => url.split("/").last
+                :value => url.split("/").last.to_s
               },
               :period => 300,
               :start_time => (Time.now.utc-660).iso8601


### PR DESCRIPTION
Fix issue where numeric AWS ids would be passed into the aws_sdk
gem as an integer instead of a string, causing an error.

@jstenhouse 
