### PR TITLE
adding new metrics to elb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**
 
 * Added AWS tag filtering for EC2 and EBS instances
+* Added new metrics to ELB: `BackendConnectionErrors`, `SurgeQueueLength`, and `SpilloverCount`
 
 **Bug Fixes**
 

--- a/lib/newrelic_aws/collectors/base.rb
+++ b/lib/newrelic_aws/collectors/base.rb
@@ -36,16 +36,34 @@ module NewRelicAWS
           raise error
         end
         NewRelic::PlatformLogger.info("Retrieved statistics: #{statistics.inspect}")
+
         point = statistics[:datapoints].last
-        return if point.nil?
-        component   = options[:component]
-        component ||= options[:dimensions].map { |dimension| dimension[:value] }.join("/")
-        statistic = options[:statistic].downcase.to_sym
-        [component, options[:metric_name], point[:unit].downcase, point[statistic]]
+        value = get_value(point, options)
+        return if value.nil?
+
+        component_name = get_component_name(options)
+        [component_name, options[:metric_name], options[:unit].downcase, value]
       end
 
       def collect
         []
+      end
+
+      private
+
+      def get_value(point, options)
+        value = options[:default_value]
+        unless point.nil?
+          statistic = options[:statistic].downcase.to_sym
+          value = point[statistic]
+        end
+        value
+      end
+
+      def get_component_name(options)
+        component_name   = options[:component_name]
+        component_name ||= options[:dimensions].map { |dimension| dimension[:value] }.join("/")
+        component_name
       end
     end
   end

--- a/lib/newrelic_aws/collectors/ebs.rb
+++ b/lib/newrelic_aws/collectors/ebs.rb
@@ -57,7 +57,7 @@ module NewRelicAWS
               },
               :period => detailed ? 60 : 300,
               :start_time => (Time.now.utc-(detailed ? 120 : 660)).iso8601,
-              :component => name_tag.nil? ? volume.id : "#{name_tag.last} (#{volume.id})"
+              :component_name => name_tag.nil? ? volume.id : "#{name_tag.last} (#{volume.id})"
             )
             NewRelic::PlatformLogger.debug("metric_name: #{metric_name}, statistic: #{statistic}, unit: #{unit}, response: #{data_point.inspect}")
             unless data_point.nil?

--- a/lib/newrelic_aws/collectors/ec2.rb
+++ b/lib/newrelic_aws/collectors/ec2.rb
@@ -53,7 +53,7 @@ module NewRelicAWS
               },
               :period => detailed ? 60 : 300,
               :start_time => (Time.now.utc-(detailed ? 120 : 660)).iso8601,
-              :component => name_tag.nil? ? instance.id : "#{name_tag.last} (#{instance.id})"
+              :component_name => name_tag.nil? ? instance.id : "#{name_tag.last} (#{instance.id})"
             )
             NewRelic::PlatformLogger.debug("metric_name: #{metric_name}, statistic: #{statistic}, unit: #{unit}, response: #{data_point.inspect}")
             unless data_point.nil?

--- a/lib/newrelic_aws/collectors/elb.rb
+++ b/lib/newrelic_aws/collectors/elb.rb
@@ -13,28 +13,32 @@ module NewRelicAWS
       def metric_list
         [
           ["Latency", "Average", "Seconds"],
-          ["RequestCount", "Sum", "Count"],
-          ["HealthyHostCount", "Maximum", "Count"],
-          ["UnHealthyHostCount", "Maximum", "Count"],
-          ["HTTPCode_ELB_4XX", "Sum", "Count"],
-          ["HTTPCode_ELB_5XX", "Sum", "Count"],
-          ["HTTPCode_Backend_2XX", "Sum", "Count"],
-          ["HTTPCode_Backend_3XX", "Sum", "Count"],
-          ["HTTPCode_Backend_4XX", "Sum", "Count"],
-          ["HTTPCode_Backend_5XX", "Sum", "Count"]
+          ["RequestCount", "Sum", "Count", 0],
+          ["HealthyHostCount", "Maximum", "Count", 0],
+          ["UnHealthyHostCount", "Maximum", "Count", 0],
+          ["HTTPCode_ELB_4XX", "Sum", "Count", 0],
+          ["HTTPCode_ELB_5XX", "Sum", "Count", 0],
+          ["HTTPCode_Backend_2XX", "Sum", "Count", 0],
+          ["HTTPCode_Backend_3XX", "Sum", "Count", 0],
+          ["HTTPCode_Backend_4XX", "Sum", "Count", 0],
+          ["HTTPCode_Backend_5XX", "Sum", "Count", 0],
+          ["BackendConnectionErrors", "Sum", "Count", 0],
+          ["SurgeQueueLength", "Maximum", "Count", 0],
+          ["SpilloverCount", "Sum", "Count", 0]
         ]
       end
 
       def collect
         data_points = []
         load_balancers.each do |load_balancer_name|
-          metric_list.each do |(metric_name, statistic, unit)|
+          metric_list.each do |(metric_name, statistic, unit, default_value)|
             data_point = get_data_point(
-              :namespace   => "AWS/ELB",
-              :metric_name => metric_name,
-              :statistic   => statistic,
-              :unit        => unit,
-              :dimension   => {
+              :namespace     => "AWS/ELB",
+              :metric_name   => metric_name,
+              :statistic     => statistic,
+              :unit          => unit,
+              :default_value => default_value,
+              :dimension     => {
                 :name  => "LoadBalancerName",
                 :value => load_balancer_name
               }


### PR DESCRIPTION
@christynicol 

FYI: @lars2893 @briandela 

Three new metrics for ELB which require a default value of 0. These are error metrics that are usually not present. When they aren't present (nil) we report 0. Added support for metric default values.
