### PR TITLE
remove premature check for valid AWS credentials

### DIFF
--- a/lib/newrelic_aws.rb
+++ b/lib/newrelic_aws.rb
@@ -32,7 +32,7 @@ module NewRelicAWS
   end
 
   def self.get_enabled_option(agent_options)
-    if agent_options['enabled'].nil? 
+    if agent_options['enabled'].nil?
       true
     else
       agent_options['enabled']
@@ -61,17 +61,17 @@ module NewRelicAWS
       def agent_options
         return @agent_options if @agent_options
         @agent_options = NewRelic::Plugin::Config.config.options
-        aws = @agent_options["aws"]
-        unless aws.is_a?(Hash) &&
-            aws["access_key"].is_a?(String) &&
-            aws["secret_key"].is_a?(String)
-          raise NewRelic::Plugin::BadConfig, "Missing or invalid AWS configuration."
+        if @agent_options["aws"].nil?
+          @agent_options["aws"] = {
+            "access_key" => nil,
+            "secret_key" => nil
+          }
         end
         @agent_options
       end
 
       def aws_regions
-        if agent_options["aws"]["regions"]
+        if !agent_options["aws"].nil? && agent_options["aws"]["regions"]
           Array(agent_options["aws"]["regions"])
         else
           AWS_REGIONS

--- a/lib/newrelic_aws/collectors/base.rb
+++ b/lib/newrelic_aws/collectors/base.rb
@@ -1,7 +1,7 @@
 module NewRelicAWS
   module Collectors
     class Base
-      def initialize(access_key, secret_key, region, options)
+      def initialize(access_key=nil, secret_key=nil, region, options)
         @aws_access_key = access_key
         @aws_secret_key = secret_key
         @aws_region = region


### PR DESCRIPTION
This PR makes specifying AWS credentials and region optional as the AWS SDK provides a number of other options that are preferable in many cases . 

AWS supports transparently and securely granting credentials to EC2 instances via IAM Roles and Instances Profiles.
A role can be created granted permissions to access the needed AWS resources. When the monitoring instance is created it is assigned the new role. The credentials (access_key, secret_key) to use are provided to the instance transparently via the instance metadata service. These credentials are automatically cycled several times a day.

The AWS SDK handles multiple levels of providing credentials, those that are directly specific like the current behaviour of this gem,  if not present then it falls to some specific ENV and if they're not present it looks at the instance profile in the instance's metadata. 

As such, with this change, this 'plugin' now supports obtaining it's credentials via `ENV['AWS_ACCESS_KEY_ID']` and `ENV['AWS_SECRET_ACCESS_KEY']` and IAM roles.

This means that a user could start up an instance, (or the AMI) and only provide the New Relic license key they would not have to hard code credentials anywhere.

http://aws.typepad.com/aws/2012/06/iam-roles-for-ec2-instances-simplified-secure-access-to-aws-service-apis-from-ec2.html
http://docs.aws.amazon.com/AWSSdkDocsRuby/latest/DeveloperGuide/ruby-dg-roles.html
http://docs.aws.amazon.com/IAM/latest/UserGuide/role-usecase-ec2app.html

Now if no credentials are present instead of NewRelic::Plugin::BadConfig an error from aws-sdk is shown: 

```
[2014-03-15 01:48:23 UTC] DEBUG: ############## start poll_cycle ############
[2014-03-15 01:48:24 UTC] ERROR: Error occurred in poll cycle: 
Missing Credentials.

Unable to find AWS credentials.  You can configure your AWS credentials
a few different ways:

* Call AWS.config with :access_key_id and :secret_access_key

* Export AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to ENV

* On EC2 you can run instances with an IAM instance profile and credentials
  will be auto loaded from the instance metadata service on those
  instances.

* Call AWS.config with :credential_provider.  A credential provider should
  either include AWS::Core::CredentialProviders::Provider or respond to
  the same public methods.

= Ruby on Rails

In a Ruby on Rails application you may also specify your credentials in
the following ways:

* Via a config initializer script using any of the methods mentioned above
  (e.g. RAILS_ROOT/config/initializers/aws-sdk.rb).

* Via a yaml configuration file located at RAILS_ROOT/config/aws.yml.
  This file should be formated like the default RAILS_ROOT/config/database.yml
  file.

```

This comes from `newrelic_plugin` and could be rescued/raised more appropriately there.
