### PR TITLE
Fix bug where using IAM roles drops specified regions

### DIFF
--- a/lib/newrelic_aws.rb
+++ b/lib/newrelic_aws.rb
@@ -67,7 +67,8 @@ module NewRelicAWS
             @agent_options["aws"] = {
               "use_aws_metadata" => true,
               "access_key" => nil,
-              "secret_key" => nil
+              "secret_key" => nil,
+              "regions" => aws["regions"]
             }
           else
             unless aws["access_key"].is_a?(String) &&


### PR DESCRIPTION
In the agent_options method, if use_aws_metadata is enabled, the
access_key and access_secret_key are set to "". Unfortunately, the value
for aws['regions'] is dropped from the config hash. This commit puts it
back in, and sets it to the value specified by the user in the plugin
config yaml file.

Signed-off-by: Mike McClurg <mike.mcclurg@gmail.com>