### PR TITLE
Added option to group EC2 instances by application, ability to give ELB human readable names, and ability to get custom metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 gem 'newrelic_plugin', '~> 1.3.0'
 gem 'nokogiri', '<= 1.5.9'
-gem 'aws-sdk', '~> 1.24.0'
+gem 'aws-sdk-v1'
 gem 'daemons'

--- a/README.md
+++ b/README.md
@@ -169,6 +169,67 @@ You will need to create a new IAM group, `NewRelicCloudWatch`, where the permiss
 
 To get API credentials, a IAM user must be created, `NewRelicCloudWatch`. Be sure to save the user access key id and secret access key on creation. Add the user to the `NewRelicCloudWatch` IAM group. Use the IAM user API credentials in the plugin configuration file.
 
+## Grouping of Servers by Application
+- This is a way to group server metrics by application. Specifically created to monitor applications in EC2 and ELB.
+- AWS instances/ELB should have have a tag "name" so that it could be filtered and grouped.
+- Access to s3 is required to access the json file that contains information of the desired application to monitor. 
+- newrelic_plugin.yml should be modified to contain the following properties (component_name_option, s3_bucket, component_name_asset)
+
+agents:
+  ec2:
+    enabled: false
+    cloudwatch_delay: 120
+    component_name_option: true
+    s3_bucket: 'ecnewrelic'
+    component_name_asset: 'component_names.json'
+  elb:
+    enabled: false
+    cloudwatch_delay: 120
+    component_name_option: true
+    s3_bucket: 'ecnewrelic'
+    component_name_asset: 'component_names.json'
+
+Example of the json file:
+
+[
+ { "condition" : "siteprod-*", "app_name" : "Production Website" },
+ { "condition" : "goprod-*", "app_name" : "Go Production" },
+ { "condition" : "wow-prod-*", "app_name" : "Wow Production" }
+]
+
+Note: the "condition" field is used to filter the instance tag "name". The "*" in the condition is a regular expression function, so feel free to use regular expression in the condition field.
+
+## Custom Metrics
+- This gives a way to gather custom metrics created specifically for your application.
+- Access to s3 is required to access the json file that contains information of the desired application to monitor. 
+- This makes use of a json file uploaded to s3 with the following format:
+  - Component name
+  - Metric name
+  - Statistics
+  - Metrics
+  - Namespace
+  - dimension
+    - name
+    - value
+
+Example of the json file:
+
+[
+  ["Recognizer Production","RecognizerRecordingQueueSize", "Average", "Count", "Recognizer", "DeploymentEnvironment", "prod"],
+  ["Recognizer Production","RecognizerRecordingQueueLatency", "Average", "Milliseconds", "Recognizer", "DeploymentEnvironment", "prod"],
+  ["Recognizer Production","RecognizerRecordingProcessingLatency", "Average", "Milliseconds", "Recognizer", "DeploymentEnvironment", "prod"],
+  ["Recognizer Production","RecognizerUploadFailure", "Sum", "Count", "Recognizer", "DeploymentEnvironment", "prod"]
+]
+
+- newrelic_plugin.yml should be modified to contain the following properties (s3_bucket, custom_metrics_asset)
+
+agents:
+  custom_metrics:
+    enabled: true
+    cloudwatch_delay: 120
+    s3_bucket: 'ecnewrelic'
+    custom_metrics_asset: 'custom_metrics.json'
+
 ## Notes
 - CloudWatch detailed monitoring is recommended, please enable it when available. (see *Using Amazon CloudWatch* section on http://aws.amazon.com/cloudwatch/)
 - Chart x-axis (time) is off by 60 seconds, this is due to CloudWatch's lag in reporting metrics.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ To get API credentials, a IAM user must be created, `NewRelicCloudWatch`. Be sur
 - AWS instances/ELB should have have a tag "name" so that it could be filtered and grouped.
 - Access to s3 is required to access the json file that contains information of the desired application to monitor. 
 - newrelic_plugin.yml should be modified to contain the following properties (component_name_option, s3_bucket, component_name_asset)
-
+```
+...
 agents:
   ec2:
     enabled: false
@@ -188,15 +189,16 @@ agents:
     component_name_option: true
     s3_bucket: 'ecnewrelic'
     component_name_asset: 'component_names.json'
-
+...
+```
 Example of the json file:
-
+```json
 [
  { "condition" : "siteprod-*", "app_name" : "Production Website" },
  { "condition" : "goprod-*", "app_name" : "Go Production" },
  { "condition" : "wow-prod-*", "app_name" : "Wow Production" }
 ]
-
+```
 Note: the "condition" field is used to filter the instance tag "name". The "*" in the condition is a regular expression function, so feel free to use regular expression in the condition field.
 
 ## Custom Metrics
@@ -213,22 +215,25 @@ Note: the "condition" field is used to filter the instance tag "name". The "*" i
     - value
 
 Example of the json file:
-
+```json
 [
   ["Recognizer Production","RecognizerRecordingQueueSize", "Average", "Count", "Recognizer", "DeploymentEnvironment", "prod"],
   ["Recognizer Production","RecognizerRecordingQueueLatency", "Average", "Milliseconds", "Recognizer", "DeploymentEnvironment", "prod"],
   ["Recognizer Production","RecognizerRecordingProcessingLatency", "Average", "Milliseconds", "Recognizer", "DeploymentEnvironment", "prod"],
   ["Recognizer Production","RecognizerUploadFailure", "Sum", "Count", "Recognizer", "DeploymentEnvironment", "prod"]
 ]
-
+```
 - newrelic_plugin.yml should be modified to contain the following properties (s3_bucket, custom_metrics_asset)
-
+```
+...
 agents:
   custom_metrics:
     enabled: true
     cloudwatch_delay: 120
     s3_bucket: 'ecnewrelic'
     custom_metrics_asset: 'custom_metrics.json'
+...
+```
 
 ## Notes
 - CloudWatch detailed monitoring is recommended, please enable it when available. (see *Using Amazon CloudWatch* section on http://aws.amazon.com/cloudwatch/)

--- a/lib/newrelic_aws.rb
+++ b/lib/newrelic_aws.rb
@@ -196,6 +196,14 @@ module NewRelicAWS
     end
   end
 
+  module CUSTOM_METRICS
+    class Agent < Base::Agent
+      agent_guid "com.newrelic.aws.custom_metrics"
+      agent_version NewRelicAWS::VERSION
+      agent_human_labels("Custom_Metrics") { "Custom_Metrics" }
+    end
+  end
+
   #
   # Register each agent with the component.
   #
@@ -203,6 +211,7 @@ module NewRelicAWS
   NewRelic::Plugin::Setup.install_agent :ebs, EBS if NewRelicAWS::agent_enabled?(:ebs)
   NewRelic::Plugin::Setup.install_agent :elb, ELB if NewRelicAWS::agent_enabled?(:elb)
   NewRelic::Plugin::Setup.install_agent :rds, RDS if NewRelicAWS::agent_enabled?(:rds)
+  NewRelic::Plugin::Setup.install_agent :custom_metrics, CUSTOM_METRICS if NewRelicAWS::agent_enabled?(:custom_metrics)
   # NewRelic::Plugin::Setup.install_agent :ddb, DDB # WIP
   NewRelic::Plugin::Setup.install_agent :sqs, SQS if NewRelicAWS::agent_enabled?(:sqs)
   NewRelic::Plugin::Setup.install_agent :sns, SNS if NewRelicAWS::agent_enabled?(:sns)

--- a/lib/newrelic_aws/collectors.rb
+++ b/lib/newrelic_aws/collectors.rb
@@ -1,5 +1,5 @@
 require "time"
-require "aws-sdk"
+require "aws-sdk-v1"
 
 require "newrelic_aws/collectors/base"
 require "newrelic_aws/collectors/ec2"
@@ -11,3 +11,4 @@ require "newrelic_aws/collectors/sqs"
 require "newrelic_aws/collectors/sns"
 require "newrelic_aws/collectors/ec"
 require "newrelic_aws/collectors/ecr"
+require "newrelic_aws/collectors/custom_metrics"

--- a/lib/newrelic_aws/collectors/base.rb
+++ b/lib/newrelic_aws/collectors/base.rb
@@ -11,6 +11,10 @@ module NewRelicAWS
           :region            => @aws_region
         )
         @cloudwatch_delay = options[:cloudwatch_delay] || 60
+        @component_name_option = options[:component_name_option]
+        @s3_bucket = options[:s3_bucket]
+        @component_names = options[:component_name_asset]
+        @custom_metrics = options[:custom_metrics_asset]
       end
 
       def get_data_point(options)
@@ -58,6 +62,18 @@ module NewRelicAWS
           value = point[statistic]
         end
         value
+      end
+
+      def get_metric_options(bucket,key)
+        unless bucket.nil? || key.nil?
+          s3 = AWS::S3.new(
+            :access_key_id     => @aws_access_key,
+            :secret_access_key => @aws_secret_key,
+            :region            => @aws_region
+          )
+          obj = s3.buckets[bucket].objects[key]
+          obj.read
+        end
       end
 
       def get_component_name(options)

--- a/lib/newrelic_aws/collectors/custom_metrics.rb
+++ b/lib/newrelic_aws/collectors/custom_metrics.rb
@@ -1,0 +1,44 @@
+module NewRelicAWS
+  module Collectors
+    class CUSTOM_METRICS < Base
+      def initialize(access_key, secret_key, region, options)
+        super(access_key, secret_key, region, options)
+      end
+
+      def metric_list
+        return get_metric_options(@s3_bucket,@custom_metrics)
+      end
+
+      def collect
+        data_points = []
+        custom_metrics = metric_list
+        unless custom_metrics.nil?
+          JSON.parse(custom_metrics).each do |(app_name, metric_name, statistic, unit, namespace, dimension_name, dimension_value)|
+            period = 60
+            time_offset = 60
+            data_point = get_data_point(
+              :namespace   => namespace,
+              :metric_name => metric_name,
+              :statistic   => statistic,
+              :unit        => unit,
+              :dimension   => {
+                :name  => dimension_name,
+                :value => dimension_value
+              },
+              :period => period,
+              :start_time => (Time.now.utc - (time_offset + period)).iso8601,
+              :end_time => (Time.now.utc - time_offset).iso8601,
+              :component_name => "#{app_name}"
+            )
+            NewRelic::PlatformLogger.debug("metric_name: #{metric_name}, statistic: #{statistic}, unit: #{unit}, response: #{data_point.inspect}")
+            unless data_point.nil?
+              data_points << data_point
+              puts data_point
+            end
+          end
+        end
+        data_points
+      end
+    end
+  end
+end

--- a/lib/newrelic_aws/collectors/elb.rb
+++ b/lib/newrelic_aws/collectors/elb.rb
@@ -2,12 +2,18 @@ module NewRelicAWS
   module Collectors
     class ELB < Base
       def load_balancers
-        elb = AWS::ELB.new(
+        @elb = AWS::ELB.new(
           :access_key_id => @aws_access_key,
           :secret_access_key => @aws_secret_key,
           :region => @aws_region
         )
-        elb.load_balancers.map { |load_balancer| load_balancer.name }
+        @elb.load_balancers.map { |load_balancer| load_balancer.name }
+      end
+
+      def define_component_names 
+        if @component_name_option
+          return get_metric_options(@s3_bucket,@component_names)
+        end
       end
 
       def metric_list
@@ -28,9 +34,42 @@ module NewRelicAWS
         ]
       end
 
+      def elb_component_name(elb_name)
+        begin
+          response = @elb.client.describe_tags( :load_balancer_names => [elb_name] )
+          name_tag = response[:tag_descriptions].first[:tags].find { |tag| tag[:key] == 'Name' }
+          elb_name = name_tag.nil? ? elb_name : name_tag[:value]
+          return elb_name
+        rescue => error
+            NewRelic::PlatformLogger.error("Unexpected error: " + error.message)
+            NewRelic::PlatformLogger.debug("Backtrace: " + error.backtrace.join("\n "))
+          raise error
+        end
+      end
+
       def collect
+        common_names = define_component_names
         data_points = []
+        app_name = nil
         load_balancers.each do |load_balancer_name|
+          name_tag = elb_component_name(load_balancer_name)
+          if name_tag.nil? then
+            next
+          end
+          unless common_names.nil?
+            JSON.parse(common_names).each do |common_name|
+              case name_tag.to_s
+              when /#{common_name['condition']}/
+                app_name = common_name['app_name']
+                break
+              else
+                next
+              end
+            end
+            if app_name.nil? then
+              next
+            end
+          end
           metric_list.each do |(metric_name, statistic, unit, default_value)|
             data_point = get_data_point(
               :namespace     => "AWS/ELB",
@@ -41,11 +80,13 @@ module NewRelicAWS
               :dimension     => {
                 :name  => "LoadBalancerName",
                 :value => load_balancer_name
-              }
+              },
+              :component_name => app_name.nil? ? load_balancer_name : "#{app_name}"
             )
             NewRelic::PlatformLogger.debug("metric_name: #{metric_name}, statistic: #{statistic}, unit: #{unit}, response: #{data_point.inspect}")
             unless data_point.nil?
               data_points << data_point
+              puts data_point
             end
           end
         end


### PR DESCRIPTION
This changes will add features to group EC2 instances and give a common component name. This will
also help in creating alerts for EC2 plugin and will not need manual modification every time new instances are launched for a application. 

Also added the ability to give ELB human readable names instead of using auto-assigned names. This is useful for applications deployed using beanstalker maven plugin. 

Lastly, added the ability to gather custom metrics. Though its just limited to a single dimension. 