### PR TITLE
Update AWS SDK to support region eu-central-1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 gem 'newrelic_plugin', '~> 1.3.0'
 gem 'nokogiri', '<= 1.5.9'
-gem 'aws-sdk', '~> 1.24.0'
+gem 'aws-sdk', '~> 1.66.0'
 gem 'daemons'


### PR DESCRIPTION
As sigv4 is required to connect in region `eu-central-1`, the AWS SDK needs to be updated.