### PR TITLE
support region eu-central-1, ap-northeast-2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 gem 'newrelic_plugin', '~> 1.3.0'
 gem 'nokogiri', '<= 1.5.9'
-gem 'aws-sdk', '~> 1.24.0'
+gem 'aws-sdk', '~> 1.66.0'
 gem 'daemons'

--- a/lib/newrelic_aws.rb
+++ b/lib/newrelic_aws.rb
@@ -23,7 +23,9 @@ module NewRelicAWS
     ap-southeast-1
     ap-southeast-2
     ap-northeast-1
+    ap-northeast-2
     sa-east-1
+    eu-central-1
   ]
 
   def self.agent_options_exist?(agent_options)


### PR DESCRIPTION
- Update AWS SDK to current version 1.66.0 to support new region (https://github.com/newrelic-platform/newrelic_aws_cloudwatch_plugin/pull/53)
- Add  eu-central-1 (https://github.com/newrelic-platform/newrelic_aws_cloudwatch_plugin/pull/43)
- Add ap-northeast-2