### PR TITLE
Adds support for IAM Role for ECS tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 gem 'newrelic_plugin', '~> 1.3.0'
 gem 'nokogiri', '<= 1.5.9'
-gem 'aws-sdk', '~> 1.66.0'
+gem 'aws-sdk', '~> 2'
 gem 'daemons'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 gem 'newrelic_plugin', '~> 1.3.0'
 gem 'nokogiri', '<= 1.5.9'
-gem 'aws-sdk', '~> 2'
+gem 'aws-sdk', '~> 2.3'
 gem 'daemons'

--- a/lib/newrelic_aws.rb
+++ b/lib/newrelic_aws.rb
@@ -20,6 +20,7 @@ module NewRelicAWS
     us-west-1
     us-west-2
     eu-west-1
+    eu-central-1
     ap-southeast-1
     ap-southeast-2
     ap-northeast-1

--- a/lib/newrelic_aws/collectors/base.rb
+++ b/lib/newrelic_aws/collectors/base.rb
@@ -2,14 +2,14 @@ module NewRelicAWS
   module Collectors
     class Base
       def initialize(access_key, secret_key, region, options)
+	      # Aws.config[:ssl_verify_peer] = false
         @aws_access_key = access_key
         @aws_secret_key = secret_key
         @aws_region = region
-        @cloudwatch = AWS::CloudWatch.new(
-          :access_key_id     => @aws_access_key,
-          :secret_access_key => @aws_secret_key,
-          :region            => @aws_region
-        )
+        @cloudwatch = Aws::CloudWatch::Client.new(
+          region:           @aws_region,
+          credentials:      Aws::Credentials.new(@aws_access_key, @aws_secret_key)
+	      )
         @cloudwatch_delay = options[:cloudwatch_delay] || 60
       end
 
@@ -20,7 +20,7 @@ module NewRelicAWS
         options[:dimensions] ||= [options[:dimension]]
         NewRelic::PlatformLogger.info("Retrieving statistics: " + options.inspect)
         begin
-          statistics = @cloudwatch.client.get_metric_statistics(
+          statistics = @cloudwatch.get_metric_statistics(
             :namespace   => options[:namespace],
             :metric_name => options[:metric_name],
             :unit        => options[:unit],

--- a/lib/newrelic_aws/collectors/base.rb
+++ b/lib/newrelic_aws/collectors/base.rb
@@ -6,9 +6,15 @@ module NewRelicAWS
         @aws_access_key = access_key
         @aws_secret_key = secret_key
         @aws_region = region
+        @credentials = if @aws_access_key
+          Aws::Credentials.new(@aws_access_key, @aws_secret_key)
+        else
+          Aws::CredentialProviderChain.new.resolve
+        end
+
         @cloudwatch = Aws::CloudWatch::Client.new(
           region:           @aws_region,
-          credentials:      Aws::Credentials.new(@aws_access_key, @aws_secret_key)
+          credentials:      @credentials
 	      )
         @cloudwatch_delay = options[:cloudwatch_delay] || 60
       end

--- a/lib/newrelic_aws/collectors/base.rb
+++ b/lib/newrelic_aws/collectors/base.rb
@@ -14,7 +14,7 @@ module NewRelicAWS
       end
 
       def get_data_point(options)
-        options[:period]     ||= 60
+        options[:period]     ||= 300
         options[:start_time] ||= (Time.now.utc - (@cloudwatch_delay + options[:period])).iso8601
         options[:end_time]   ||= (Time.now.utc - @cloudwatch_delay).iso8601
         options[:dimensions] ||= [options[:dimension]]

--- a/lib/newrelic_aws/collectors/ddb.rb
+++ b/lib/newrelic_aws/collectors/ddb.rb
@@ -4,7 +4,7 @@ module NewRelicAWS
       def tables
         ddb = Aws::DynamoDB::Resource.new(
           region:           @aws_region,
-          credentials:      Aws::Credentials.new(@aws_access_key, @aws_secret_key)
+          credentials:      @credentials
         )
         ddb.tables.map { |table| table.name }
       end

--- a/lib/newrelic_aws/collectors/ddb.rb
+++ b/lib/newrelic_aws/collectors/ddb.rb
@@ -2,9 +2,9 @@ module NewRelicAWS
   module Collectors
     class DDB < Base
       def tables
-        ddb = AWS::DynamoDB.new(
-          :access_key_id => @aws_access_key,
-          :secret_access_key => @aws_secret_key
+        ddb = Aws::DynamoDB::Resource.new(
+          region:           @aws_region,
+          credentials:      Aws::Credentials.new(@aws_access_key, @aws_secret_key)
         )
         ddb.tables.map { |table| table.name }
       end

--- a/lib/newrelic_aws/collectors/ebs.rb
+++ b/lib/newrelic_aws/collectors/ebs.rb
@@ -15,7 +15,7 @@ module NewRelicAWS
           tagged_volumes
         else
           @ec2.volumes(filters: [{ name: "status", values: ["in-use"] }])
-	end
+	      end
       end
 
       def tagged_volumes

--- a/lib/newrelic_aws/collectors/ebs.rb
+++ b/lib/newrelic_aws/collectors/ebs.rb
@@ -5,7 +5,7 @@ module NewRelicAWS
         super(access_key, secret_key, region, options)
         @ec2 = Aws::EC2::Resource.new(
           region:           @aws_region,
-          credentials:      Aws::Credentials.new(@aws_access_key, @aws_secret_key)
+          credentials:      @credentials
         )
         @tags = options[:tags]
         @detailed = options[:detailed] || false

--- a/lib/newrelic_aws/collectors/ebs.rb
+++ b/lib/newrelic_aws/collectors/ebs.rb
@@ -43,7 +43,7 @@ module NewRelicAWS
         data_points = []
         volumes.each do |volume|
           detailed = !!volume.iops
-          name_tag = volume.tags.detect { |tag| tag.first =~ /^name$/i }
+          name_tag = volume.tags.detect { |tag| tag.key =~ /^name$/i }
           metric_list.each do |(metric_name, statistic, unit)|
             period = detailed ? 60 : 300
             time_offset = detailed ? 60 : 600

--- a/lib/newrelic_aws/collectors/ebs.rb
+++ b/lib/newrelic_aws/collectors/ebs.rb
@@ -48,7 +48,7 @@ module NewRelicAWS
           name_tag = volume.tags.detect { |tag| tag.key =~ /^name$/i }
           metric_list.each do |(metric_name, statistic, unit)|
             period = @detailed ? 60 : 300
-            time_offset = @detailed ? 60 : 600
+            time_offset = @detailed ? 60 : 300
             time_offset += @cloudwatch_delay
             data_point = get_data_point(
               :namespace   => "AWS/EBS",

--- a/lib/newrelic_aws/collectors/ec.rb
+++ b/lib/newrelic_aws/collectors/ec.rb
@@ -4,7 +4,7 @@ module NewRelicAWS
       def clusters(engine = 'memcached')
         ec = Aws::ElastiCache::Client.new(
           region:      @aws_region,
-          credentials: Aws::Credentials.new(@aws_access_key, @aws_secret_key)
+          credentials: @credentials
         )
         clusters = ec.describe_cache_clusters(:show_cache_node_info => true)
         clusters[:cache_clusters].map do |cluster|

--- a/lib/newrelic_aws/collectors/ec.rb
+++ b/lib/newrelic_aws/collectors/ec.rb
@@ -6,7 +6,7 @@ module NewRelicAWS
           region:      @aws_region,
           credentials: Aws::Credentials.new(@aws_access_key, @aws_secret_key)
         )
-        clusters = ec.client.describe_cache_clusters(:show_cache_node_info => true)
+        clusters = ec.describe_cache_clusters(:show_cache_node_info => true)
         clusters[:cache_clusters].map do |cluster|
           if cluster[:engine] == engine
             {

--- a/lib/newrelic_aws/collectors/ec.rb
+++ b/lib/newrelic_aws/collectors/ec.rb
@@ -2,10 +2,9 @@ module NewRelicAWS
   module Collectors
     class EC < Base
       def clusters(engine = 'memcached')
-        ec = AWS::ElastiCache.new(
-          :access_key_id => @aws_access_key,
-          :secret_access_key => @aws_secret_key,
-          :region => @aws_region
+        ec = AWS::ElastiCache::Client.new(
+          region:      @aws_region,
+          credentials: Aws::Credentials.new(@aws_access_key, @aws_secret_key)
         )
         clusters = ec.client.describe_cache_clusters(:show_cache_node_info => true)
         clusters[:cache_clusters].map do |cluster|

--- a/lib/newrelic_aws/collectors/ec.rb
+++ b/lib/newrelic_aws/collectors/ec.rb
@@ -2,7 +2,7 @@ module NewRelicAWS
   module Collectors
     class EC < Base
       def clusters(engine = 'memcached')
-        ec = AWS::ElastiCache::Client.new(
+        ec = Aws::ElastiCache::Client.new(
           region:      @aws_region,
           credentials: Aws::Credentials.new(@aws_access_key, @aws_secret_key)
         )

--- a/lib/newrelic_aws/collectors/ec2.rb
+++ b/lib/newrelic_aws/collectors/ec2.rb
@@ -19,9 +19,17 @@ module NewRelicAWS
       end
 
       def tagged_instances
-        instances = @ec2.instances.tagged(@tags).to_a
-        instances.concat(@ec2.instances.tagged('Name', 'name').tagged_values(@tags).to_a)
-        instances
+        # instances = @ec2.instances.tagged(@tags).to_a
+        # instances.concat(@ec2.instances.tagged('Name', 'name').tagged_values(@tags).to_a)
+        # instances
+        instances = @ec2.instances({
+          filters: [
+            {
+              name: 'tag:Name',
+              values: ["@tags"]
+            }
+          ]
+          })
       end
 
       def metric_list
@@ -37,6 +45,7 @@ module NewRelicAWS
 
       def collect
         data_points = []
+        NewRelic::PlatformLogger.debug("instances: #{instances.inspect}")
         instances.each do |instance|
           detailed = instance.monitoring == :enabled
           name_tag = instance.tags.detect { |tag| tag.first =~ /^name$/i }

--- a/lib/newrelic_aws/collectors/ec2.rb
+++ b/lib/newrelic_aws/collectors/ec2.rb
@@ -19,17 +19,9 @@ module NewRelicAWS
       end
 
       def tagged_instances
-        # instances = @ec2.instances.tagged(@tags).to_a
-        # instances.concat(@ec2.instances.tagged('Name', 'name').tagged_values(@tags).to_a)
-        # instances
-        instances = @ec2.instances({
-          filters: [
-            {
-              name: 'tag:Name',
-              values: ["@tags"]
-            }
-          ]
-          })
+        instances = @ec2.instances.tagged(@tags).to_a
+        instances.concat(@ec2.instances.tagged('Name', 'name').tagged_values(@tags).to_a)
+        instances
       end
 
       def metric_list
@@ -48,7 +40,7 @@ module NewRelicAWS
         instances.each do |instance|
           detailed = instance.monitoring == :enabled
           NewRelic::PlatformLogger.debug("tags: #{instance.tags.inspect}")
-          name_tag = instance.tags.detect { |tag| tag.first =~ /^name$/i }
+          name_tag = instance.tags.detect { |tag| tag.key =~ /^name$/i }
           metric_list.each do |(metric_name, statistic, unit)|
             period = detailed ? 60 : 300
             time_offset = detailed ? 60 : 600

--- a/lib/newrelic_aws/collectors/ec2.rb
+++ b/lib/newrelic_aws/collectors/ec2.rb
@@ -38,7 +38,7 @@ module NewRelicAWS
       def collect
         data_points = []
         instances.each do |instance|
-          detailed = instance.monitoring == :enabled
+          detailed = instance.monitoring.state == "enabled"
           name_tag = instance.tags.detect { |tag| tag.key =~ /^name$/i }
           metric_list.each do |(metric_name, statistic, unit)|
             period = detailed ? 60 : 300

--- a/lib/newrelic_aws/collectors/ec2.rb
+++ b/lib/newrelic_aws/collectors/ec2.rb
@@ -3,11 +3,10 @@ module NewRelicAWS
     class EC2 < Base
       def initialize(access_key, secret_key, region, options)
         super(access_key, secret_key, region, options)
-        @ec2 = AWS::EC2.new(
-          :access_key_id => @aws_access_key,
-          :secret_access_key => @aws_secret_key,
-          :region => @aws_region
-        )
+        @ec2 = Aws::EC2::Resource.new(
+          region:           @aws_region,
+          credentials:      Aws::Credentials.new(@aws_access_key, @aws_secret_key)
+	         )
         @tags = options[:tags]
       end
 
@@ -57,7 +56,7 @@ module NewRelicAWS
               :period => period,
               :start_time => (Time.now.utc - (time_offset + period)).iso8601,
               :end_time => (Time.now.utc - time_offset).iso8601,
-              :component_name => name_tag.nil? ? instance.id : "#{name_tag.last} (#{instance.id})"
+              :component_name => name_tag.nil? ? instance.id : "#{name_tag.value} (#{instance.id})"
             )
             NewRelic::PlatformLogger.debug("metric_name: #{metric_name}, statistic: #{statistic}, unit: #{unit}, response: #{data_point.inspect}")
             unless data_point.nil?

--- a/lib/newrelic_aws/collectors/ec2.rb
+++ b/lib/newrelic_aws/collectors/ec2.rb
@@ -39,7 +39,6 @@ module NewRelicAWS
         data_points = []
         instances.each do |instance|
           detailed = instance.monitoring == :enabled
-          NewRelic::PlatformLogger.debug("tags: #{instance.tags.inspect}")
           name_tag = instance.tags.detect { |tag| tag.key =~ /^name$/i }
           metric_list.each do |(metric_name, statistic, unit)|
             period = detailed ? 60 : 300

--- a/lib/newrelic_aws/collectors/ec2.rb
+++ b/lib/newrelic_aws/collectors/ec2.rb
@@ -45,9 +45,9 @@ module NewRelicAWS
 
       def collect
         data_points = []
-        NewRelic::PlatformLogger.debug("instances: #{instances.inspect}")
         instances.each do |instance|
           detailed = instance.monitoring == :enabled
+          NewRelic::PlatformLogger.debug("tags: #{instance.tags.inspect}")
           name_tag = instance.tags.detect { |tag| tag.first =~ /^name$/i }
           metric_list.each do |(metric_name, statistic, unit)|
             period = detailed ? 60 : 300

--- a/lib/newrelic_aws/collectors/ec2.rb
+++ b/lib/newrelic_aws/collectors/ec2.rb
@@ -5,7 +5,7 @@ module NewRelicAWS
         super(access_key, secret_key, region, options)
         @ec2 = Aws::EC2::Resource.new(
           region:           @aws_region,
-          credentials:      Aws::Credentials.new(@aws_access_key, @aws_secret_key)
+          credentials:      @credentials
 	      )
         @tags = options[:tags]
       end

--- a/lib/newrelic_aws/collectors/ec2.rb
+++ b/lib/newrelic_aws/collectors/ec2.rb
@@ -6,7 +6,7 @@ module NewRelicAWS
         @ec2 = Aws::EC2::Resource.new(
           region:           @aws_region,
           credentials:      Aws::Credentials.new(@aws_access_key, @aws_secret_key)
-	         )
+	      )
         @tags = options[:tags]
       end
 

--- a/lib/newrelic_aws/collectors/elb.rb
+++ b/lib/newrelic_aws/collectors/elb.rb
@@ -2,12 +2,11 @@ module NewRelicAWS
   module Collectors
     class ELB < Base
       def load_balancers
-        elb = AWS::ELB.new(
-          :access_key_id => @aws_access_key,
-          :secret_access_key => @aws_secret_key,
-          :region => @aws_region
+        elb = Aws::ElasticLoadBalancing::Client.new(
+          region:           @aws_region,
+          credentials:      Aws::Credentials.new(@aws_access_key, @aws_secret_key)
         )
-        elb.load_balancers.map { |load_balancer| load_balancer.name }
+        elb.describe_load_balancers().load_balancer_descriptions.map { |load_balancer| load_balancer.load_balancer_name  }
       end
 
       def metric_list

--- a/lib/newrelic_aws/collectors/elb.rb
+++ b/lib/newrelic_aws/collectors/elb.rb
@@ -4,7 +4,7 @@ module NewRelicAWS
       def load_balancers
         elb = Aws::ElasticLoadBalancing::Client.new(
           region:           @aws_region,
-          credentials:      Aws::Credentials.new(@aws_access_key, @aws_secret_key)
+          credentials:      @credentials
         )
         elb.describe_load_balancers().load_balancer_descriptions.map { |load_balancer| load_balancer.load_balancer_name  }
       end

--- a/lib/newrelic_aws/collectors/rds.rb
+++ b/lib/newrelic_aws/collectors/rds.rb
@@ -8,12 +8,11 @@ module NewRelicAWS
 
       def instance_ids
         return @instance_ids if @instance_ids
-        rds = AWS::RDS.new(
-          :access_key_id => @aws_access_key,
-          :secret_access_key => @aws_secret_key,
-          :region => @aws_region
+        rds = Aws::RDS::Resource.new(
+          region:           @aws_region,
+          credentials:      Aws::Credentials.new(@aws_access_key, @aws_secret_key)
         )
-        rds.instances.map { |instance| instance.id }
+        rds.db_instances.map { |instance| instance.id }
       end
 
       def metric_list

--- a/lib/newrelic_aws/collectors/rds.rb
+++ b/lib/newrelic_aws/collectors/rds.rb
@@ -10,7 +10,7 @@ module NewRelicAWS
         return @instance_ids if @instance_ids
         rds = Aws::RDS::Resource.new(
           region:           @aws_region,
-          credentials:      Aws::Credentials.new(@aws_access_key, @aws_secret_key)
+          credentials:      @credentials
         )
         rds.db_instances.map { |instance| instance.id }
       end

--- a/lib/newrelic_aws/collectors/sns.rb
+++ b/lib/newrelic_aws/collectors/sns.rb
@@ -2,10 +2,9 @@ module NewRelicAWS
   module Collectors
     class SNS < Base
       def topic_names
-        sns = AWS::SNS.new(
-          :access_key_id => @aws_access_key,
-          :secret_access_key => @aws_secret_key,
-          :region => @aws_region
+        sns = Aws::SNS::Resource.new(
+          region:      @aws_region,
+          credentials: Aws::Credentials.new(@aws_access_key, @aws_secret_key)
         )
         sns.topics.map { |topic| topic.name }
       end

--- a/lib/newrelic_aws/collectors/sns.rb
+++ b/lib/newrelic_aws/collectors/sns.rb
@@ -4,7 +4,7 @@ module NewRelicAWS
       def topic_names
         sns = Aws::SNS::Resource.new(
           region:      @aws_region,
-          credentials: Aws::Credentials.new(@aws_access_key, @aws_secret_key)
+          credentials: @credentials
         )
         sns.topics.map { |topic| topic.name }
       end

--- a/lib/newrelic_aws/collectors/sqs.rb
+++ b/lib/newrelic_aws/collectors/sqs.rb
@@ -2,10 +2,9 @@ module NewRelicAWS
   module Collectors
     class SQS < Base
       def queue_urls
-        sqs = AWS::SQS.new(
-          :access_key_id => @aws_access_key,
-          :secret_access_key => @aws_secret_key,
-          :region => @aws_region
+        sqs = Aws::SQS::Resource.new(
+          region:      @aws_region,
+          credentials: Aws::Credentials.new(@aws_access_key, @aws_secret_key)
         )
         sqs.queues.map { |queue| queue.url }
       end

--- a/lib/newrelic_aws/collectors/sqs.rb
+++ b/lib/newrelic_aws/collectors/sqs.rb
@@ -4,7 +4,7 @@ module NewRelicAWS
       def queue_urls
         sqs = Aws::SQS::Resource.new(
           region:      @aws_region,
-          credentials: Aws::Credentials.new(@aws_access_key, @aws_secret_key)
+          credentials: @credentials
         )
         sqs.queues.map { |queue| queue.url }
       end

--- a/lib/newrelic_aws/version.rb
+++ b/lib/newrelic_aws/version.rb
@@ -1,3 +1,3 @@
 module NewRelicAWS
-  VERSION = '3.3.3'
+  VERSION = '3.3.4'
 end


### PR DESCRIPTION
Adds ability to support IAM roles to resolve AWS credentials for ECS container tasks which requires `aws-sdk` 2.3+ [ref](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html#enable_task_iam_roles)

Much thanks to the [`rocket-sysadmins`](https://github.com/rocket-sysadmins/newrelic_aws_cloudwatch_plugin) for the great work of upgrading the `aws-sdk` to 2.x that made all this possible!
