### PR TITLE
Modify regions config key to use proper YAML syntax in all places

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,9 @@ The plugin can also be configured to query specific CloudWatch regions, e.g. `us
 
 ```
   regions:
-    -
-      us-east-1
-    -
-      us-east-2
-    -
-      us-west-1
+    - us-east-1
+    - us-east-2
+    - us-west-1
 ```
 
 ### Amazon ElastiCache

--- a/config/template_newrelic_plugin.yml
+++ b/config/template_newrelic_plugin.yml
@@ -27,11 +27,9 @@ aws:
   #use_aws_metadata: true
 
   # Specify AWS regions to query for metrics
-  # regions:
-  #  -
-  #   us-west-1
-  #  -
-  #   us-east-2
+  #regions:
+  #  - us-west-1
+  #  - us-east-2
 
 #
 # Agent configuration.


### PR DESCRIPTION
The YAML syntax seems to occasionally result in errors when the plugin parses configuration that's "styled" like the example config. file. The core issue might actually be related to whitespace, and this change just makes the YAML examples more canonical to hopefully reduce such problems.